### PR TITLE
Исправляем проблему с ненулевым значением session.cookie_lifetime

### DIFF
--- a/upload/catalog/controller/startup/session.php
+++ b/upload/catalog/controller/startup/session.php
@@ -22,7 +22,7 @@ class ControllerStartupSession extends Controller {
 			
 			$this->session->start($session_id);
 			
-			setcookie($this->config->get('session_name'), $this->session->getId(), ini_get('session.cookie_lifetime'), ini_get('session.cookie_path'), ini_get('session.cookie_domain'));	
+			setcookie($this->config->get('session_name'), $this->session->getId(), ini_get('session.cookie_lifetime') > 0 ? (time() + ini_get('session.cookie_lifetime')) : 0, ini_get('session.cookie_path'), ini_get('session.cookie_domain'));
 		}
 	}
 }

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -109,7 +109,7 @@ if ($config->get('session_autostart')) {
 
 	$session->start($session_id);
 
-	setcookie($config->get('session_name'), $session->getId(), ini_get('session.cookie_lifetime'), ini_get('session.cookie_path'), ini_get('session.cookie_domain'));
+	setcookie($config->get('session_name'), $session->getId(), ini_get('session.cookie_lifetime') > 0 ? (time() + ini_get('session.cookie_lifetime')) : 0, ini_get('session.cookie_path'), ini_get('session.cookie_domain'));
 }
 
 // Cache


### PR DESCRIPTION
Если значение session.cookie_lifetime не нулевое, то время жизни сессии попадало в прошлое из-за некорректного вызова setcookie.