### PR TITLE
Доработка события event/language

### DIFF
--- a/upload/admin/controller/event/language.php
+++ b/upload/admin/controller/event/language.php
@@ -10,17 +10,11 @@ class ControllerEventLanguage extends Controller {
 
 	// 1. Before controller load store all current loaded language data
 	public function before(&$route, &$output) {
-		$this->language->set('backup', $this->language->all());
+		$this->language->backup();
 	}
 
 	// 2. After contoller load restore old language data
 	public function after(&$route, &$args, &$output) {
-		$data = $this->language->get('backup');
-
-		if (is_array($data)) {
-			foreach ($data as $key => $value) {
-				$this->language->set($key, $value);
-			}
-		}
+		$this->language->restore();
 	}
 }

--- a/upload/catalog/controller/event/language.php
+++ b/upload/catalog/controller/event/language.php
@@ -10,17 +10,11 @@ class ControllerEventLanguage extends Controller {
 	
 	// 1. Before controller load store all current loaded language data
 	public function before(&$route, &$output) {
-		$this->language->set('backup', $this->language->all());
+		$this->language->backup();
 	}
 	
 	// 2. After contoller load restore old language data
 	public function after(&$route, &$args, &$output) {
-		$data = $this->language->get('backup');
-		
-		if (is_array($data)) {
-			foreach ($data as $key => $value) {
-				$this->language->set($key, $value);
-			}
-		}
+		$this->language->restore();
 	}
 }

--- a/upload/system/library/language.php
+++ b/upload/system/library/language.php
@@ -11,9 +11,10 @@
 * Language class
 */
 class Language {
-	private $default = 'en-gb';
+	private $default = 'ru-ru';
 	private $directory;
 	public $data = array();
+	private $backup = array();
 	
 	/**
 	 * Constructor
@@ -82,4 +83,14 @@ class Language {
 		
 		return $this->data;
 	}
+	  
+    public function backup() {
+        $this->backup[] = $this->data;
+    }
+    
+    public function restore() {
+        if (count($this->backup) > 0) {
+            $this->data = array_pop($this->backup);
+        }
+    }
 }


### PR DESCRIPTION
Событие выполняется до и после каждого контроллера, для сохранения и восстановления языковых переменных.
Сохранение велось в data[backup], что приводило к разрастанию дерева переменных, и эти
ненужные переменные все выгружались во view:
```
array(
  ...
  backup => array(`
    ...
    backup => array(
      ...
      backup => array(
        ...
    )
  )
)
```

Для исключения такой ситуации добавлен отдельный массив для сохранения языковых переменных.